### PR TITLE
Remove manual translations

### DIFF
--- a/translation.py
+++ b/translation.py
@@ -49,12 +49,6 @@ class TextFileTranslator:
             'F': 'F'
         }
 
-        # Manual translations for phrases that are sometimes left untranslated
-        self.manual_translations = {
-            'TELEPHONE': 'TELÉFONO',
-            'WHERE YOU MAY BE REACHED': 'DÓNDE SE LE PUEDE LOCALIZAR',
-            'AMERICAN INDIAN': 'INDÍGENA AMERICANO'
-        }
 
     def is_form_header_or_code(self, text: str) -> bool:
         """Check if text is a form header or code that should be preserved"""
@@ -156,11 +150,6 @@ class TextFileTranslator:
             if clean_text.upper() in self.yn_replacements:
                 return self.yn_replacements[clean_text.upper()]
 
-            # Manual translation overrides
-            manual_key = clean_text.upper()
-            if manual_key in self.manual_translations:
-                manual = self.manual_translations[manual_key]
-                return self._preserve_capitalization(clean_text, manual)
 
             # Build context-aware prompt
             context_info = ""


### PR DESCRIPTION
## Summary
- remove manual translation rules in `TextFileTranslator`

## Testing
- `python3 -m py_compile translation.py`

------
https://chatgpt.com/codex/tasks/task_e_68716c7303dc8323936909a38afc5b2c